### PR TITLE
Changing copyright and information links

### DIFF
--- a/herrnhuterlosung.php
+++ b/herrnhuterlosung.php
@@ -93,7 +93,7 @@ class Losung_Widget extends WP_Widget {
 		}
 		
 		#Copyright ausgeben
-		echo '<p class="losung-copy"><a href="http://www.herrnhuter.de" target="_blank" title="Evangelische Br&uuml;der-Unit&auml;t">&copy; Evangelische Br&uuml;der-Unit&auml;t – Herrnhuter Br&uuml;dergemeine</a> <br> <a href="http://www.losungen.de" target="_blank" title="www.losungen.de">Weitere Informationen finden Sie hier</a></p>';
+		echo '<p class="losung-copy"><a href="http://www.herrnhuter.de" target="_blank" title="Evangelische Br&uuml;der-Unit&auml;t">&copy; Evangelische Br&uuml;der-Unit&auml;t – Herrnhuter Br&uuml;dergemeine</a> <br> <a href="https://www.losungen.de" target="_blank" title="www.losungen.de">Weitere Informationen finden Sie hier</a></p>';
 	}
 	
 	function showBibleVers($text, $vers, $options = array())

--- a/herrnhuterlosung.php
+++ b/herrnhuterlosung.php
@@ -93,7 +93,7 @@ class Losung_Widget extends WP_Widget {
 		}
 		
 		#Copyright ausgeben
-		echo '<p class="losung-copy"><a href="http://www.ebu.de" target="_blank" title="Evangelische Br&uuml;der-Unit&auml;t">&copy; Evangelische Br&uuml;der-Unit&auml;t – Herrnhuter Br&uuml;dergemeine</a> <br> <a href="http://www.losungen.de" target="_blank" title="www.losungen.de">Weitere Informationen finden Sie hier</a></p>';
+		echo '<p class="losung-copy"><a href="http://www.herrnhuter.de" target="_blank" title="Evangelische Br&uuml;der-Unit&auml;t">&copy; Evangelische Br&uuml;der-Unit&auml;t – Herrnhuter Br&uuml;dergemeine</a> <br> <a href="http://www.losungen.de" target="_blank" title="www.losungen.de">Weitere Informationen finden Sie hier</a></p>';
 	}
 	
 	function showBibleVers($text, $vers, $options = array())


### PR DESCRIPTION
IAW the Nutzungsbedingungen from January 2107 the copyright link has to be www.herrrhuter.de which redirects to https://www.ebu.de/startseite/. 

https://www.herrnhuter.de is under construction and has a wrong certificate. just in case you intend to change this also to https.

http://www.losungen.de redirects to https://www.losungen.de 
