### PR TITLE
remove WP_DEBUG check for URL

### DIFF
--- a/lib/xml_automatic_updater.php
+++ b/lib/xml_automatic_updater.php
@@ -53,11 +53,7 @@ class HerrnhuterLosungenPlugin_Xml_Automatic_Update
 
 	protected function _getDownloadUrl($date)
 	{
-		if (WP_DEBUG)
-			$url = 'http://localhost/local/Losung_%s_XML.zip';
-		else
-			$url = apply_filters('herrnhuterlosung_download_url', self::DOWNLOAD_URL);
-		return sprintf($url, (int) $date['year']);	
+		return sprintf(apply_filters('herrnhuterlosung_download_url', self::DOWNLOAD_URL), (int) $date['year']);
 	}
 	
 	public function updater_gui()


### PR DESCRIPTION
fixes #9
the URL should not be different depending on the WP_DEBUG constant.
for local testing, the URL can be filtered.